### PR TITLE
Medicine Logic

### DIFF
--- a/src/main/java/seedu/clinicio/commons/core/Messages.java
+++ b/src/main/java/seedu/clinicio/commons/core/Messages.java
@@ -13,4 +13,7 @@ public class Messages {
             + "is invalid";
     public static final String MESSAGE_APPOINTMENTS_LISTED_OVERVIEW = "%1$d appointments listed!";
 
+    public static final String MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX = "The medicine index provided is invalid";
+    public static final String MESSAGE_MEDICINE_OVERVIEW = "%1$d medicine details listed!";
+
 }

--- a/src/main/java/seedu/clinicio/logic/Logic.java
+++ b/src/main/java/seedu/clinicio/logic/Logic.java
@@ -7,6 +7,7 @@ import seedu.clinicio.logic.commands.exceptions.CommandException;
 import seedu.clinicio.logic.parser.exceptions.ParseException;
 
 import seedu.clinicio.model.appointment.Appointment;
+import seedu.clinicio.model.medicine.Medicine;
 import seedu.clinicio.model.patient.Patient;
 import seedu.clinicio.model.person.Person;
 import seedu.clinicio.model.staff.Staff;
@@ -35,6 +36,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of appointments. */
     ObservableList<Appointment> getFilteredAppointmentList();
+
+    /** Returns an unmodifiable view of the filtered list of medicines */
+    ObservableList<Medicine> getFilteredMedicineList();
 
     /** Returns an unmodifiable view of the filtered list of patients. */
     ObservableList<Person> getAllPatientsInQueue();

--- a/src/main/java/seedu/clinicio/logic/LogicManager.java
+++ b/src/main/java/seedu/clinicio/logic/LogicManager.java
@@ -15,6 +15,7 @@ import seedu.clinicio.logic.parser.exceptions.ParseException;
 
 import seedu.clinicio.model.Model;
 import seedu.clinicio.model.appointment.Appointment;
+import seedu.clinicio.model.medicine.Medicine;
 import seedu.clinicio.model.patient.Patient;
 import seedu.clinicio.model.person.Person;
 import seedu.clinicio.model.staff.Staff;
@@ -64,6 +65,11 @@ public class LogicManager extends ComponentManager implements Logic {
     @Override
     public ObservableList<Appointment> getFilteredAppointmentList() {
         return model.getFilteredAppointmentList();
+    }
+
+    @Override
+    public ObservableList<Medicine> getFilteredMedicineList() {
+        return model.getFilteredMedicineList();
     }
 
     public ObservableList<Person> getAllPatientsInQueue() {

--- a/src/main/java/seedu/clinicio/logic/commands/AddMedicineCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/AddMedicineCommand.java
@@ -1,0 +1,75 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static java.util.Objects.requireNonNull;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_NAME;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_TYPE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_EFFECTIVE_DOSAGE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_LETHAL_DOSAGE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_PRICE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_QUANTITY;
+
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.logic.commands.exceptions.CommandException;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.medicine.Medicine;
+
+/**
+ * Adds a medicine to the medicine inventory.
+ */
+
+public class AddMedicineCommand extends Command {
+
+    public static final String COMMAND_WORD = "addmed";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a medicine to the medicine inventory. "
+            + "Parameters: "
+            + PREFIX_MEDICINE_NAME + "MEDICINE NAME "
+            + PREFIX_MEDICINE_TYPE + "MEDICINE TYPE "
+            + PREFIX_MEDICINE_EFFECTIVE_DOSAGE + "EFFECTIVE DOSAGE "
+            + PREFIX_MEDICINE_LETHAL_DOSAGE + "LETHAL DOSAGE "
+            + PREFIX_MEDICINE_PRICE + "PRICE "
+            + PREFIX_MEDICINE_QUANTITY + "QUANTITY "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_MEDICINE_NAME + "Paracetamol "
+            + PREFIX_MEDICINE_TYPE + "tablet "
+            + PREFIX_MEDICINE_EFFECTIVE_DOSAGE + "2 "
+            + PREFIX_MEDICINE_LETHAL_DOSAGE + "8 "
+            + PREFIX_MEDICINE_PRICE + "0.10 "
+            + PREFIX_MEDICINE_QUANTITY + "1000 ";
+
+    public static final String MESSAGE_SUCCESS = "New medicine added: %1$s";
+    public static final String MESSAGE_DUPLICATE_MEDICINE = "This medicine already exists in the medicine inventory";
+
+    private final Medicine toAddMedicine;
+
+    /**
+     * Creates an AddMedicineCommand to add the specified {@code Medicine}
+     */
+    public AddMedicineCommand(Medicine medicine) {
+        requireNonNull(medicine);
+        toAddMedicine = medicine;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasMedicine(toAddMedicine)) {
+            throw new CommandException(MESSAGE_DUPLICATE_MEDICINE);
+        }
+
+        model.addMedicine(toAddMedicine);
+        model.commitClinicIo();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAddMedicine));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddMedicineCommand // instanceof handles nulls
+                && toAddMedicine.equals(((AddMedicineCommand) other).toAddMedicine));
+    }
+
+}

--- a/src/main/java/seedu/clinicio/logic/commands/DeleteMedicineCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/DeleteMedicineCommand.java
@@ -46,7 +46,7 @@ public class DeleteMedicineCommand extends Command {
         Medicine medicineToDelete = medicineList.get(targetIndex.getZeroBased());
         model.deleteMedicine(medicineToDelete);
         model.commitClinicIo();
-        return new CommandResult(String.format(MESSAGE_DELETE_MEDICINE_SUCCESS, medicineList));
+        return new CommandResult(String.format(MESSAGE_DELETE_MEDICINE_SUCCESS, medicineToDelete));
     }
 
     @Override

--- a/src/main/java/seedu/clinicio/logic/commands/DeleteMedicineCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/DeleteMedicineCommand.java
@@ -1,0 +1,59 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.clinicio.commons.core.Messages;
+import seedu.clinicio.commons.core.index.Index;
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.logic.commands.exceptions.CommandException;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.medicine.Medicine;
+
+/**
+ * Removes a medicine from the medicine inventory using it's displayed index from the ClinicIO.
+ */
+
+public class DeleteMedicineCommand extends Command {
+
+    public static final String COMMAND_WORD = "deletemed";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the medicine identified by the index number used in the displayed medicine list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_MEDICINE_SUCCESS = "Deleted Medicine: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteMedicineCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Medicine> medicineList = model.getFilteredMedicineList();
+
+        if (targetIndex.getZeroBased() >= medicineList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+        }
+
+        Medicine medicineToDelete = medicineList.get(targetIndex.getZeroBased());
+        model.deleteMedicine(medicineToDelete);
+        model.commitClinicIo();
+        return new CommandResult(String.format(MESSAGE_DELETE_MEDICINE_SUCCESS, medicineList));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteMedicineCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteMedicineCommand) other).targetIndex)); // state check
+    }
+
+}

--- a/src/main/java/seedu/clinicio/logic/commands/FindMedicineCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/FindMedicineCommand.java
@@ -1,0 +1,47 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.clinicio.commons.core.Messages;
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.medicine.MedicineNameContainsKeywordsPredicate;
+
+/**
+ * Finds medicine in medicine inventory whose name matches the keyword.
+ * Keyword matching is case insensitive.
+ */
+public class FindMedicineCommand extends Command{
+
+    public static final String COMMAND_WORD = "findmed";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds medicine whose names matches "
+            + "the specified keyword (case-insensitive) "
+            + "and displays the medicine properties as a list.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " paracetamol";
+
+    private final MedicineNameContainsKeywordsPredicate predicate;
+
+    public FindMedicineCommand(MedicineNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.updateFilteredMedicineList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_MEDICINE_OVERVIEW, model.getFilteredMedicineList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindMedicineCommand // instanceof handles nulls
+                && predicate.equals(((FindMedicineCommand) other).predicate)); // state check
+    }
+
+}

--- a/src/main/java/seedu/clinicio/logic/commands/ListMedicineCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/ListMedicineCommand.java
@@ -1,0 +1,26 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static java.util.Objects.requireNonNull;
+import static seedu.clinicio.model.Model.PREDICATE_SHOW_ALL_MEDICINES;
+
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+
+/**
+ * Lists all medicines in the medicine inventory to the user.
+ */
+public class ListMedicineCommand extends Command {
+
+    public static final String COMMAND_WORD = "listmed";
+
+    public static final String MESSAGE_SUCCESS = "Listed all medicines";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.updateFilteredMedicineList(PREDICATE_SHOW_ALL_MEDICINES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/clinicio/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/RedoCommand.java
@@ -1,6 +1,7 @@
 package seedu.clinicio.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.clinicio.model.Model.PREDICATE_SHOW_ALL_MEDICINES;
 import static seedu.clinicio.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.clinicio.logic.CommandHistory;
@@ -26,6 +27,7 @@ public class RedoCommand extends Command {
 
         model.redoClinicIo();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredMedicineList(PREDICATE_SHOW_ALL_MEDICINES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/clinicio/logic/commands/SelectMedicineCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/SelectMedicineCommand.java
@@ -1,0 +1,60 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.clinicio.commons.core.EventsCenter;
+import seedu.clinicio.commons.core.Messages;
+import seedu.clinicio.commons.core.index.Index;
+import seedu.clinicio.commons.events.ui.JumpToListRequestEvent;
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.logic.commands.exceptions.CommandException;
+import seedu.clinicio.model.Model;
+
+import seedu.clinicio.model.medicine.Medicine;
+
+/**
+ * Selects a medicine identified using it's displayed index from the medicine inventory.
+ */
+public class SelectMedicineCommand extends Command {
+
+    public static final String COMMAND_WORD = "selectmed";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Selects the medicine identified by the index number used in the displayed medicine list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SELECT_MEDICINE_SUCCESS = "Selected Medicine: %1$s";
+
+    private final Index targetIndex;
+
+    public SelectMedicineCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        List<Medicine> filteredMedicineList = model.getFilteredMedicineList();
+
+        if (targetIndex.getZeroBased() >= filteredMedicineList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+        }
+
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex));
+        return new CommandResult(String.format(MESSAGE_SELECT_MEDICINE_SUCCESS, targetIndex.getOneBased()));
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SelectMedicineCommand // instanceof handles nulls
+                && targetIndex.equals(((SelectMedicineCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/clinicio/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/clinicio/logic/commands/UndoCommand.java
@@ -1,6 +1,7 @@
 package seedu.clinicio.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.clinicio.model.Model.PREDICATE_SHOW_ALL_MEDICINES;
 import static seedu.clinicio.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.clinicio.logic.CommandHistory;
@@ -26,6 +27,7 @@ public class UndoCommand extends Command {
 
         model.undoClinicIo();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredMedicineList(PREDICATE_SHOW_ALL_MEDICINES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/clinicio/logic/parser/AddMedicineCommandParser.java
+++ b/src/main/java/seedu/clinicio/logic/parser/AddMedicineCommandParser.java
@@ -1,0 +1,67 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_NAME;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_TYPE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_EFFECTIVE_DOSAGE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_LETHAL_DOSAGE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_PRICE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_QUANTITY;
+
+import java.util.stream.Stream;
+
+import seedu.clinicio.logic.commands.AddMedicineCommand;
+import seedu.clinicio.logic.parser.exceptions.ParseException;
+import seedu.clinicio.model.medicine.Medicine;
+import seedu.clinicio.model.medicine.MedicineName;
+import seedu.clinicio.model.medicine.MedicineType;
+import seedu.clinicio.model.medicine.MedicineDosage;
+import seedu.clinicio.model.medicine.MedicinePrice;
+import seedu.clinicio.model.medicine.MedicineQuantity;
+
+/**
+ * Parses input arguments and creates a new AddMedicineCommand object
+ */
+public class AddMedicineCommandParser implements Parser<AddMedicineCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddMedicineCommand
+     * and returns an AddMedicineCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddMedicineCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_MEDICINE_NAME, PREFIX_MEDICINE_TYPE,
+                        PREFIX_MEDICINE_EFFECTIVE_DOSAGE, PREFIX_MEDICINE_LETHAL_DOSAGE,
+                        PREFIX_MEDICINE_PRICE, PREFIX_MEDICINE_QUANTITY);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_MEDICINE_NAME, PREFIX_MEDICINE_TYPE,
+                PREFIX_MEDICINE_EFFECTIVE_DOSAGE, PREFIX_MEDICINE_LETHAL_DOSAGE,
+                PREFIX_MEDICINE_PRICE, PREFIX_MEDICINE_QUANTITY)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMedicineCommand.MESSAGE_USAGE));
+        }
+
+        MedicineName name = ParserUtil.parseMedicineName(argMultimap.getValue(PREFIX_MEDICINE_NAME).get());
+        MedicineType type = ParserUtil.parseMedicineType(argMultimap.getValue(PREFIX_MEDICINE_TYPE).get());
+        MedicineDosage effectiveDosage = ParserUtil.parseDosage(argMultimap.getValue(PREFIX_MEDICINE_EFFECTIVE_DOSAGE).get());
+        MedicineDosage lethalDosage = ParserUtil.parseDosage(argMultimap.getValue(PREFIX_MEDICINE_LETHAL_DOSAGE).get());
+        MedicinePrice price = ParserUtil.parsePrice(argMultimap.getValue(PREFIX_MEDICINE_PRICE).get());
+        MedicineQuantity quantity = ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_MEDICINE_QUANTITY).get());
+
+        Medicine medicine = new Medicine(name, type, effectiveDosage, lethalDosage, price, quantity);
+
+        return new AddMedicineCommand(medicine);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/clinicio/logic/parser/ClinicIoParser.java
+++ b/src/main/java/seedu/clinicio/logic/parser/ClinicIoParser.java
@@ -8,12 +8,14 @@ import java.util.regex.Pattern;
 
 import seedu.clinicio.logic.commands.AddApptCommand;
 import seedu.clinicio.logic.commands.AddCommand;
+import seedu.clinicio.logic.commands.AddMedicineCommand;
 import seedu.clinicio.logic.commands.AddPatientCommand;
 import seedu.clinicio.logic.commands.AppointmentStatisticsCommand;
 import seedu.clinicio.logic.commands.CancelApptCommand;
 import seedu.clinicio.logic.commands.ClearCommand;
 import seedu.clinicio.logic.commands.Command;
 import seedu.clinicio.logic.commands.DeleteCommand;
+import seedu.clinicio.logic.commands.DeleteMedicineCommand;
 import seedu.clinicio.logic.commands.DequeueCommand;
 import seedu.clinicio.logic.commands.DoctorStatisticsCommand;
 import seedu.clinicio.logic.commands.EditCommand;
@@ -23,15 +25,18 @@ import seedu.clinicio.logic.commands.ExportPatientsAppointmentsCommand;
 import seedu.clinicio.logic.commands.ExportPatientsCommand;
 import seedu.clinicio.logic.commands.ExportPatientsConsultationsCommand;
 import seedu.clinicio.logic.commands.FindCommand;
+import seedu.clinicio.logic.commands.FindMedicineCommand;
 import seedu.clinicio.logic.commands.HelpCommand;
 import seedu.clinicio.logic.commands.HistoryCommand;
 import seedu.clinicio.logic.commands.ListApptCommand;
 import seedu.clinicio.logic.commands.ListCommand;
+import seedu.clinicio.logic.commands.ListMedicineCommand;
 import seedu.clinicio.logic.commands.LoginCommand;
 import seedu.clinicio.logic.commands.LogoutCommand;
 import seedu.clinicio.logic.commands.PatientStatisticsCommand;
 import seedu.clinicio.logic.commands.RedoCommand;
 import seedu.clinicio.logic.commands.SelectCommand;
+import seedu.clinicio.logic.commands.SelectMedicineCommand;
 import seedu.clinicio.logic.commands.ShowPatientInQueueCommand;
 import seedu.clinicio.logic.commands.UndoCommand;
 
@@ -141,9 +146,24 @@ public class ClinicIoParser {
         case DequeueCommand.COMMAND_WORD:
             return new DequeueCommandParser().parse(arguments);
 
-        case ShowPatientInQueueCommand
-                .COMMAND_WORD:
+        case ShowPatientInQueueCommand.COMMAND_WORD:
             return new ShowPatientInQueueCommand();
+
+        case AddMedicineCommand.COMMAND_WORD:
+            return new AddMedicineCommandParser().parse(arguments);
+
+        case DeleteMedicineCommand.COMMAND_WORD:
+            return new DeleteMedicineCommandParser().parse(arguments);
+
+        case FindMedicineCommand.COMMAND_WORD:
+            return new FindMedicineCommandParser().parse(arguments);
+
+        case ListMedicineCommand.COMMAND_WORD:
+            return new ListMedicineCommand();
+
+        case SelectMedicineCommand.COMMAND_WORD:
+            return new SelectMedicineCommandParser().parse(arguments);
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/clinicio/logic/parser/DeleteMedicineCommandParser.java
+++ b/src/main/java/seedu/clinicio/logic/parser/DeleteMedicineCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.clinicio.commons.core.index.Index;
+import seedu.clinicio.logic.commands.DeleteMedicineCommand;
+import seedu.clinicio.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteMedicineCommand object
+ */
+public class DeleteMedicineCommandParser implements Parser<DeleteMedicineCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMedicineCommand
+     * and returns a DeleteMedicineCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteMedicineCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteMedicineCommand(index);
+        } catch (ParseException parseException) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicineCommand.MESSAGE_USAGE), parseException);
+        }
+    }
+
+}

--- a/src/main/java/seedu/clinicio/logic/parser/FindMedicineCommandParser.java
+++ b/src/main/java/seedu/clinicio/logic/parser/FindMedicineCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.clinicio.logic.commands.FindMedicineCommand;
+import seedu.clinicio.logic.parser.exceptions.ParseException;
+import seedu.clinicio.model.medicine.MedicineNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindMedicineCommand object
+ */
+public class FindMedicineCommandParser implements Parser<FindMedicineCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindMedicineCommand
+     * and returns a FindMedicineCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindMedicineCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMedicineCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindMedicineCommand(new MedicineNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/clinicio/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/clinicio/logic/parser/ParserUtil.java
@@ -16,6 +16,11 @@ import seedu.clinicio.logic.parser.exceptions.ParseException;
 
 import seedu.clinicio.model.appointment.Date;
 import seedu.clinicio.model.appointment.Time;
+import seedu.clinicio.model.medicine.MedicineDosage;
+import seedu.clinicio.model.medicine.MedicineName;
+import seedu.clinicio.model.medicine.MedicinePrice;
+import seedu.clinicio.model.medicine.MedicineQuantity;
+import seedu.clinicio.model.medicine.MedicineType;
 import seedu.clinicio.model.patient.Allergy;
 import seedu.clinicio.model.patient.MedicalProblem;
 import seedu.clinicio.model.patient.Medication;
@@ -322,4 +327,85 @@ public class ParserUtil {
         }
         return new Staff(DOCTOR, new Name(trimmedDoctorName));
     }
+
+    //@@author aaronseahyh
+    /**
+     * Parses a {@code String medicineName} into a {@code MedicineName}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code medicinename} is invalid.
+     */
+    public static MedicineName parseMedicineName(String medicineName) throws ParseException {
+        requireNonNull(medicineName);
+        String trimmedName = medicineName.trim();
+        if (!MedicineName.isValidMedicineName(trimmedName)) {
+            throw new ParseException(MedicineName.MESSAGE_MEDICINE_NAME_CONSTRAINTS);
+        }
+        return new MedicineName(trimmedName);
+    }
+
+    //@@author aaronseahyh
+    /**
+     * Parses a {@code String medicineType} into a {@code MedicineType}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code medicineType} is invalid.
+     */
+    public static MedicineType parseMedicineType(String medicineType) throws ParseException {
+        requireNonNull(medicineType);
+        String trimmedType = medicineType.trim();
+        if (!MedicineType.isValidType(trimmedType)) {
+            throw new ParseException(MedicineType.MESSAGE_MEDICINE_TYPE_CONSTRAINTS);
+        }
+        return new MedicineType(trimmedType);
+    }
+
+    //@@author aaronseahyh
+    /**
+     * Parses a {@code String dosage} into a {@code MedicineDosage}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code dosage} is invalid.
+     */
+    public static MedicineDosage parseDosage(String dosage) throws ParseException {
+        requireNonNull(dosage);
+        String trimmedDosage = dosage.trim();
+        if (!MedicineDosage.isValidMedicineDosage(trimmedDosage)) {
+            throw new ParseException(MedicineDosage.MESSAGE_MEDICINE_DOSAGE_CONSTRAINTS);
+        }
+        return new MedicineDosage(trimmedDosage);
+    }
+
+    //@@author aaronseahyh
+    /**
+     * Parses a {@code String price} into a {@code MedicinePrice}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code price} is invalid.
+     */
+    public static MedicinePrice parsePrice(String price) throws ParseException {
+        requireNonNull(price);
+        String trimmedPrice = price.trim();
+        if (!MedicinePrice.isValidMedicinePrice(trimmedPrice)) {
+            throw new ParseException(MedicinePrice.MESSAGE_MEDICINE_PRICE_CONSTRAINTS);
+        }
+        return new MedicinePrice(trimmedPrice);
+    }
+
+    //@@author aaronseahyh
+    /**
+     * Parses a {@code String quantity} into a {@code MedicineQuantity}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code quantity} is invalid.
+     */
+    public static MedicineQuantity parseQuantity(String quantity) throws ParseException {
+        requireNonNull(quantity);
+        String trimmedQuantity = quantity.trim();
+        if (!MedicineQuantity.isValidMedicineQuantity(trimmedQuantity)) {
+            throw new ParseException(MedicineQuantity.MESSAGE_MEDICINE_QUANTITY_CONSTRAINTS);
+        }
+        return new MedicineQuantity(trimmedQuantity);
+    }
+
 }

--- a/src/main/java/seedu/clinicio/logic/parser/SelectMedicineCommandParser.java
+++ b/src/main/java/seedu/clinicio/logic/parser/SelectMedicineCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.clinicio.commons.core.index.Index;
+import seedu.clinicio.logic.commands.SelectMedicineCommand;
+import seedu.clinicio.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SelectMedicineCommand object
+ */
+public class SelectMedicineCommandParser implements Parser<SelectMedicineCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SelectMedicineCommand
+     * and returns an SelectMedicineCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SelectMedicineCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new SelectMedicineCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectMedicineCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/test/java/seedu/clinicio/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/clinicio/logic/LogicManagerTest.java
@@ -65,6 +65,12 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void getFilteredMedicineList_modifyList_throwsUnsupportedOperationException() {
+        thrown.expect(UnsupportedOperationException.class);
+        logic.getFilteredMedicineList().remove(0);
+    }
+
+    @Test
     public void getAllPatientsInQueue_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         logic.getAllPatientsInQueue().remove(0);

--- a/src/test/java/seedu/clinicio/logic/commands/AddMedicineCommandIntegrationTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/AddMedicineCommandIntegrationTest.java
@@ -1,0 +1,53 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.ModelManager;
+import seedu.clinicio.model.UserPrefs;
+import seedu.clinicio.model.analytics.Analytics;
+import seedu.clinicio.model.medicine.Medicine;
+import seedu.clinicio.testutil.MedicineBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddMedicineCommand}.
+ */
+public class AddMedicineCommandIntegrationTest {
+
+    private Model model;
+    private CommandHistory commandHistory = new CommandHistory();
+    private Analytics analytics = new Analytics();
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_newMedicine_success() {
+        Medicine validMedicine = new MedicineBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getClinicIo(), new UserPrefs());
+        expectedModel.addMedicine(validMedicine);
+        expectedModel.commitClinicIo();
+
+        assertCommandSuccess(new AddMedicineCommand(validMedicine), model, commandHistory,
+                String.format(AddMedicineCommand.MESSAGE_SUCCESS, validMedicine), expectedModel, analytics);
+    }
+
+    @Test
+    public void execute_duplicateMedicine_throwsCommandException() {
+        Medicine medicineInList = model.getClinicIo().getMedicineList().get(0);
+        assertCommandFailure(new AddMedicineCommand(medicineInList), model, commandHistory,
+                analytics, AddMedicineCommand.MESSAGE_DUPLICATE_MEDICINE);
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/commands/AddMedicineCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/AddMedicineCommandTest.java
@@ -1,0 +1,439 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_MEDICINENAME_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_MEDICINENAME_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_MEDICINETYPE_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_MEDICINETYPE_PARACETAMOL;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javafx.collections.ObservableList;
+
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.logic.commands.exceptions.CommandException;
+
+import seedu.clinicio.model.ClinicIo;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.ReadOnlyClinicIo;
+import seedu.clinicio.model.analytics.StatisticType;
+import seedu.clinicio.model.appointment.Appointment;
+import seedu.clinicio.model.consultation.Consultation;
+import seedu.clinicio.model.medicine.Medicine;
+import seedu.clinicio.model.medicine.MedicineQuantity;
+import seedu.clinicio.model.patient.Patient;
+import seedu.clinicio.model.person.Person;
+import seedu.clinicio.model.staff.Staff;
+
+import seedu.clinicio.testutil.MedicineBuilder;
+
+public class AddMedicineCommandTest {
+
+    private static final CommandHistory EMPTY_COMMAND_HISTORY = new CommandHistory();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void constructor_nullMedicine_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new AddMedicineCommand(null);
+    }
+
+    @Test
+    public void execute_medicineAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingMedicineAdded modelStub = new ModelStubAcceptingMedicineAdded();
+        Medicine validMedicine = new MedicineBuilder().build();
+
+        CommandResult commandResult = new AddMedicineCommand(validMedicine).execute(modelStub, commandHistory);
+
+        assertEquals(String.format(AddMedicineCommand.MESSAGE_SUCCESS, validMedicine), commandResult.feedbackToUser);
+        assertEquals(Arrays.asList(validMedicine), modelStub.medicinesAdded);
+        assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
+    }
+
+    @Test
+    public void execute_duplicateMedicine_throwsCommandException() throws Exception {
+        Medicine validMedicine = new MedicineBuilder().build();
+        AddMedicineCommand addMedicineCommand = new AddMedicineCommand(validMedicine);
+        ModelStub modelStub = new ModelStubWithMedicine(validMedicine);
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(AddMedicineCommand.MESSAGE_DUPLICATE_MEDICINE);
+        addMedicineCommand.execute(modelStub, commandHistory);
+    }
+
+    @Test
+    public void equals() {
+        Medicine oracort = new MedicineBuilder().withMedicineName(VALID_MEDICINENAME_ORACORT)
+                .withMedicineType(VALID_MEDICINETYPE_ORACORT).build();
+        Medicine paracetamol = new MedicineBuilder().withMedicineName(VALID_MEDICINENAME_PARACETAMOL)
+                .withMedicineType(VALID_MEDICINETYPE_PARACETAMOL).build();
+        AddMedicineCommand addOracortCommand = new AddMedicineCommand(oracort);
+        AddMedicineCommand addParacetamolCommand = new AddMedicineCommand(paracetamol);
+
+        // same object -> returns true
+        assertTrue(addOracortCommand.equals(addOracortCommand));
+
+        // same values -> returns true
+        AddMedicineCommand addOracortCommandCopy = new AddMedicineCommand(oracort);
+        assertTrue(addOracortCommand.equals(addOracortCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addOracortCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addOracortCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(addOracortCommand.equals(addParacetamolCommand));
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPatient(Patient patient) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addStaff(Staff staff) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author jjlee050
+        @Override
+        public boolean checkStaffCredentials(Staff staff) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void resetData(ReadOnlyClinicIo newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyClinicIo getClinicIo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPatient(Patient patient) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasStaff(Staff staff) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updatePerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Patient> getFilteredPatientList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getAllPatientsInQueue() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Staff> getFilteredStaffList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPatientList(Predicate<Patient> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author jjlee050
+        @Override
+        public void updateFilteredStaffList(Predicate<Staff> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canUndoClinicIo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canRedoClinicIo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void undoClinicIo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void redoClinicIo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void commitClinicIo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author iamjackslayer
+        @Override
+        public void enqueue(Patient patient) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void dequeue(Patient patient) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void enqueueIntoMainQueue(Person patient) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void enqueueIntoPreferenceQueue(Person patient) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPatientInMainQueue() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPatientInPreferenceQueue() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPatientInPatientQueue() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasConsultation(Consultation consultation) {
+            return false;
+        }
+
+        @Override
+        public void deleteConsultation(Consultation target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addConsultation(Consultation consultation) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateConsultation(Consultation target, Consultation editedConsultation) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Consultation> getFilteredConsultationList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredConsultationList(Predicate<Consultation> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String exportPatients() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String exportPatientsAppointments() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String exportPatientsConsultations() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author gingivitiss
+        @Override
+        public boolean hasAppointment(Appointment appt) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasAppointmentClash(Appointment appt) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteAppointment(Appointment appt) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void cancelAppointment(Appointment appt) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addAppointment(Appointment appt) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateAppointment(Appointment appt, Appointment editedAppt) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Appointment> getFilteredAppointmentList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void requestAnalyticsDisplay(StatisticType statisticType) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author aaronseahyh
+        @Override
+        public boolean hasMedicine(Medicine medicine) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author aaronseahyh
+        @Override
+        public void deleteMedicine(Medicine medicine) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author aaronseahyh
+        @Override
+        public void addMedicine(Medicine medicine) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author aaronseahyh
+        @Override
+        public void updateMedicineQuantity(Medicine medicine, MedicineQuantity newQuantity) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author aaronseahyh
+        @Override
+        public ObservableList<Medicine> getFilteredMedicineList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //@@author aaronseahyh
+        @Override
+        public void updateFilteredMedicineList(Predicate<Medicine> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+    }
+
+    /**
+     * A Model stub that contains a single medicine.
+     */
+    private class ModelStubWithMedicine extends AddMedicineCommandTest.ModelStub {
+        private final Medicine medicine;
+
+        ModelStubWithMedicine(Medicine medicine) {
+            requireNonNull(medicine);
+            this.medicine = medicine;
+        }
+
+        @Override
+        public boolean hasMedicine(Medicine medicine) {
+            requireNonNull(medicine);
+            return this.medicine.isSameMedicine(medicine);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the medicine being added.
+     */
+    private class ModelStubAcceptingMedicineAdded extends ModelStub {
+        final ArrayList<Medicine> medicinesAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasMedicine(Medicine medicine) {
+            requireNonNull(medicine);
+            return medicinesAdded.stream().anyMatch(medicine::isSameMedicine);
+        }
+
+        @Override
+        public void addMedicine(Medicine medicine) {
+            requireNonNull(medicine);
+            medicinesAdded.add(medicine);
+        }
+
+        @Override
+        public void commitClinicIo() {
+            // called by {@code AddCommand#execute()}
+        }
+
+        @Override
+        public ReadOnlyClinicIo getClinicIo() {
+            return new ClinicIo();
+        }
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/clinicio/logic/commands/CommandTestUtil.java
@@ -31,6 +31,8 @@ import seedu.clinicio.logic.commands.exceptions.CommandException;
 import seedu.clinicio.model.ClinicIo;
 import seedu.clinicio.model.Model;
 import seedu.clinicio.model.analytics.Analytics;
+import seedu.clinicio.model.medicine.Medicine;
+import seedu.clinicio.model.medicine.MedicineNameContainsKeywordsPredicate;
 import seedu.clinicio.model.person.NameContainsKeywordsPredicate;
 import seedu.clinicio.model.person.Person;
 import seedu.clinicio.testutil.EditPersonDescriptorBuilder;
@@ -162,52 +164,28 @@ public class CommandTestUtil {
 
     public static final String MEDICINENAME_DESC_PARACETAMOL = " " + PREFIX_MEDICINE_NAME
             + VALID_MEDICINENAME_PARACETAMOL;
-    public static final String MEDICINENAME_DESC_VENTOLIN = " " + PREFIX_MEDICINE_NAME
-            + VALID_MEDICINENAME_VENTOLIN;
     public static final String MEDICINENAME_DESC_ORACORT = " " + PREFIX_MEDICINE_NAME
             + VALID_MEDICINENAME_ORACORT;
-    public static final String MEDICINENAME_DESC_CHLORPHENIRAMINE = " " + PREFIX_MEDICINE_NAME
-            + VALID_MEDICINENAME_CHLORPHENIRAMINE;
     public static final String MEDICINETYPE_DESC_PARACETAMOL = " " + PREFIX_MEDICINE_TYPE
             + VALID_MEDICINETYPE_PARACETAMOL;
-    public static final String MEDICINETYPE_DESC_VENTOLIN = " " + PREFIX_MEDICINE_TYPE
-            + VALID_MEDICINETYPE_VENTOLIN;
     public static final String MEDICINETYPE_DESC_ORACORT = " " + PREFIX_MEDICINE_TYPE
             + VALID_MEDICINETYPE_ORACORT;
-    public static final String MEDICINETYPE_DESC_CHLORPHENIRAMINE = " " + PREFIX_MEDICINE_TYPE
-            + VALID_MEDICINETYPE_CHLORPHENIRAMINE;
     public static final String EFFECTIVEDOSAGE_DESC_PARACETAMOL = " " + PREFIX_MEDICINE_EFFECTIVE_DOSAGE
             + VALID_EFFECTIVEDOSAGE_PARACETAMOL;
-    public static final String EFFECTIVEDOSAGE_DESC_VENTOLIN = " " + PREFIX_MEDICINE_EFFECTIVE_DOSAGE
-            + VALID_EFFECTIVEDOSAGE_VENTOLIN;
     public static final String EFFECTIVEDOSAGE_DESC_ORACORT = " " + PREFIX_MEDICINE_EFFECTIVE_DOSAGE
             + VALID_EFFECTIVEDOSAGE_ORACORT;
-    public static final String EFFECTIVEDOSAGE_DESC_CHLORPHENIRAMINE = " " + PREFIX_MEDICINE_EFFECTIVE_DOSAGE
-            + VALID_EFFECTIVEDOSAGE_CHLORPHENIRAMINE;
     public static final String LETHALDOSAGE_DESC_PARACETAMOL = " " + PREFIX_MEDICINE_LETHAL_DOSAGE
             + VALID_LETHALDOSAGE_PARACETAMOL;
-    public static final String LETHALDOSAGE_DESC_VENTOLIN = " " + PREFIX_MEDICINE_LETHAL_DOSAGE
-            + VALID_LETHALDOSAGE_VENTOLIN;
     public static final String LETHALDOSAGE_DESC_ORACORT = " " + PREFIX_MEDICINE_LETHAL_DOSAGE
             + VALID_LETHALDOSAGE_ORACORT;
-    public static final String LETHALDOSAGE_DESC_CHLORPHENIRAMINE = " " + PREFIX_MEDICINE_LETHAL_DOSAGE
-            + VALID_LETHALDOSAGE_CHLORPHENIRAMINE;
     public static final String PRICE_DESC_PARACETAMOL = " " + PREFIX_MEDICINE_PRICE
             + VALID_PRICE_PARACETAMOL;
-    public static final String PRICE_DESC_VENTOLIN = " " + PREFIX_MEDICINE_PRICE
-            + VALID_PRICE_VENTOLIN;
     public static final String PRICE_DESC_ORACORT = " " + PREFIX_MEDICINE_PRICE
             + VALID_PRICE_ORACORT;
-    public static final String PRICE_DESC_CHLORPHENIRAMINE = " " + PREFIX_MEDICINE_PRICE
-            + VALID_PRICE_CHLORPHENIRAMINE;
     public static final String QUANTITY_DESC_PARACETAMOL = " " + PREFIX_MEDICINE_QUANTITY
             + VALID_QUANTITY_PARACETAMOL;
-    public static final String QUANTITY_DESC_VENTOLIN = " " + PREFIX_MEDICINE_QUANTITY
-            + VALID_QUANTITY_VENTOLIN;
     public static final String QUANTITY_DESC_ORACORT = " " + PREFIX_MEDICINE_QUANTITY
             + VALID_QUANTITY_ORACORT;
-    public static final String QUANTITY_DESC_CHLORPHENIRAMINE = " " + PREFIX_MEDICINE_QUANTITY
-            + VALID_QUANTITY_CHLORPHENIRAMINE;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -227,10 +205,10 @@ public class CommandTestUtil {
 
     public static final String INVALID_MEDICINENAME_DESC = " " + PREFIX_MEDICINE_NAME + "Cheese&";
     public static final String INVALID_MEDICINETYPE_DESC = " " + PREFIX_MEDICINE_TYPE + "Cheese1";
-    public static final String INVALID_EFFECTIVEDOSAGE_DESC = " " + PREFIX_MEDICINE_TYPE + "Cheese2";
-    public static final String INVALID_LETHALDOSAGE_DESC = " " + PREFIX_MEDICINE_TYPE + "Cheese3";
-    public static final String INVALID_PRICE_DESC = " " + PREFIX_MEDICINE_TYPE + "Cheese4";
-    public static final String INVALID_QUANTITY_DESC = " " + PREFIX_MEDICINE_TYPE + "Cheese5";
+    public static final String INVALID_EFFECTIVEDOSAGE_DESC = " " + PREFIX_MEDICINE_EFFECTIVE_DOSAGE + "Cheese2";
+    public static final String INVALID_LETHALDOSAGE_DESC = " " + PREFIX_MEDICINE_LETHAL_DOSAGE + "Cheese3";
+    public static final String INVALID_PRICE_DESC = " " + PREFIX_MEDICINE_PRICE + "Cheese4";
+    public static final String INVALID_QUANTITY_DESC = " " + PREFIX_MEDICINE_QUANTITY + "Cheese5";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -311,6 +289,31 @@ public class CommandTestUtil {
     public static void deleteFirstPerson(Model model) {
         Person firstPerson = model.getFilteredPersonList().get(0);
         model.deletePerson(firstPerson);
+        model.commitClinicIo();
+    }
+
+    //@@author aaronseahyh
+    /**
+     * Updates {@code model}'s filtered list to show only the medicine at the given {@code targetIndex} in the
+     * {@code model}'s ClinicIO.
+     */
+    public static void showMedicineAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredMedicineList().size());
+
+        Medicine medicine = model.getFilteredMedicineList().get(targetIndex.getZeroBased());
+        final String[] splitName = medicine.getMedicineName().medicineName.split("\\s+");
+        model.updateFilteredMedicineList(new MedicineNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredMedicineList().size());
+    }
+
+    //@@author aaronseahyh
+    /**
+     * Deletes the first medicine in {@code model}'s filtered medicine list from {@code model}'s ClinicIO.
+     */
+    public static void deleteFirstMedicine(Model model) {
+        Medicine firstMedicine = model.getFilteredMedicineList().get(0);
+        model.deleteMedicine(firstMedicine);
         model.commitClinicIo();
     }
 

--- a/src/test/java/seedu/clinicio/logic/commands/DeleteMedicineCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/DeleteMedicineCommandTest.java
@@ -1,0 +1,189 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.logic.commands.CommandTestUtil.showMedicineAtIndex;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_SECOND_MEDICINE;
+import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
+
+import org.junit.Test;
+
+import seedu.clinicio.commons.core.Messages;
+import seedu.clinicio.commons.core.index.Index;
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.ModelManager;
+import seedu.clinicio.model.UserPrefs;
+import seedu.clinicio.model.analytics.Analytics;
+import seedu.clinicio.model.medicine.Medicine;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
+ * {@code DeleteMedicineCommand}.
+ */
+public class DeleteMedicineCommandTest {
+
+    private Model model = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+    private Analytics analytics = new Analytics();
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Medicine medicineToDelete = model.getFilteredMedicineList().get(INDEX_FIRST_MEDICINE.getZeroBased());
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(INDEX_FIRST_MEDICINE);
+
+        String expectedMessage = String.format(DeleteMedicineCommand.MESSAGE_DELETE_MEDICINE_SUCCESS, medicineToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getClinicIo(), new UserPrefs());
+        expectedModel.deleteMedicine(medicineToDelete);
+        expectedModel.commitClinicIo();
+
+        assertCommandSuccess(deleteMedicineCommand, model, commandHistory, expectedMessage, expectedModel, analytics);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMedicineList().size() + 1);
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteMedicineCommand, model, commandHistory, analytics,
+                Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showMedicineAtIndex(model, INDEX_FIRST_MEDICINE);
+
+        Medicine medicineToDelete = model.getFilteredMedicineList().get(INDEX_FIRST_MEDICINE.getZeroBased());
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(INDEX_FIRST_MEDICINE);
+
+        String expectedMessage = String.format(DeleteMedicineCommand.MESSAGE_DELETE_MEDICINE_SUCCESS, medicineToDelete);
+
+        Model expectedModel = new ModelManager(model.getClinicIo(), new UserPrefs());
+        expectedModel.deleteMedicine(medicineToDelete);
+        expectedModel.commitClinicIo();
+        showNoMedicine(expectedModel);
+
+        assertCommandSuccess(deleteMedicineCommand, model, commandHistory, expectedMessage, expectedModel, analytics);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showMedicineAtIndex(model, INDEX_FIRST_MEDICINE);
+
+        Index outOfBoundIndex = INDEX_SECOND_MEDICINE;
+        // ensures that outOfBoundIndex is still in bounds of ClinicIO list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getClinicIo().getMedicineList().size());
+
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteMedicineCommand, model, commandHistory, analytics,
+                Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
+        Medicine medicineToDelete = model.getFilteredMedicineList().get(INDEX_FIRST_MEDICINE.getZeroBased());
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(INDEX_FIRST_MEDICINE);
+        Model expectedModel = new ModelManager(model.getClinicIo(), new UserPrefs());
+        expectedModel.deleteMedicine(medicineToDelete);
+        expectedModel.commitClinicIo();
+
+        // delete -> first medicine deleted
+        deleteMedicineCommand.execute(model, commandHistory);
+
+        // undo -> reverts ClinicIO back to previous state and filtered medicine list to show all medicines
+        expectedModel.undoClinicIo();
+        assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel,
+                analytics);
+
+        // redo -> same first medicine deleted again
+        expectedModel.redoClinicIo();
+        assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel,
+                analytics);
+    }
+
+    @Test
+    public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMedicineList().size() + 1);
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(outOfBoundIndex);
+
+        // execution failed -> ClinicIO state not added into model
+        assertCommandFailure(deleteMedicineCommand, model, commandHistory, analytics,
+                Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+
+        // single ClinicIO state in model -> undoCommand and redoCommand fail
+        assertCommandFailure(new UndoCommand(), model, commandHistory, analytics, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new RedoCommand(), model, commandHistory, analytics, RedoCommand.MESSAGE_FAILURE);
+    }
+
+    /**
+     * 1. Deletes a {@code Medicine} from a filtered list.
+     * 2. Undo the deletion.
+     * 3. The unfiltered list should be shown now. Verify that the index of the previously deleted medicine in the
+     * unfiltered list is different from the index at the filtered list.
+     * 4. Redo the deletion. This ensures {@code RedoCommand} deletes the medicine object regardless of indexing.
+     */
+    @Test
+    public void executeUndoRedo_validIndexFilteredList_sameMedicineDeleted() throws Exception {
+        DeleteMedicineCommand deleteMedicineCommand = new DeleteMedicineCommand(INDEX_FIRST_MEDICINE);
+        Model expectedModel = new ModelManager(model.getClinicIo(), new UserPrefs());
+
+        showMedicineAtIndex(model, INDEX_SECOND_MEDICINE);
+        Medicine medicineToDelete = model.getFilteredMedicineList().get(INDEX_FIRST_MEDICINE.getZeroBased());
+        expectedModel.deleteMedicine(medicineToDelete);
+        expectedModel.commitClinicIo();
+
+        // delete -> deletes second medicine in unfiltered medicine list / first medicine in filtered medicine list
+        deleteMedicineCommand.execute(model, commandHistory);
+
+        // undo -> reverts ClinicIO back to previous state and filtered medicine list to show all medicines
+        expectedModel.undoClinicIo();
+        assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel,
+                analytics);
+
+        assertNotEquals(medicineToDelete, model.getFilteredMedicineList().get(INDEX_FIRST_MEDICINE.getZeroBased()));
+        // redo -> deletes same second medicine in unfiltered medicine list
+        expectedModel.redoClinicIo();
+        assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel,
+                analytics);
+    }
+
+    @Test
+    public void equals() {
+        DeleteMedicineCommand deleteFirstMedicineCommand = new DeleteMedicineCommand(INDEX_FIRST_MEDICINE);
+        DeleteMedicineCommand deleteSecondMedicineCommand = new DeleteMedicineCommand(INDEX_SECOND_MEDICINE);
+
+        // same object -> returns true
+        assertTrue(deleteFirstMedicineCommand.equals(deleteFirstMedicineCommand));
+
+        // same values -> returns true
+        DeleteMedicineCommand deleteFirstMedicineCommandCopy = new DeleteMedicineCommand(INDEX_FIRST_MEDICINE);
+        assertTrue(deleteFirstMedicineCommand.equals(deleteFirstMedicineCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstMedicineCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstMedicineCommand.equals(null));
+
+        // different medicine -> returns false
+        assertFalse(deleteFirstMedicineCommand.equals(deleteSecondMedicineCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no medicines.
+     */
+    private void showNoMedicine(Model model) {
+        model.updateFilteredMedicineList(m -> false);
+
+        assertTrue(model.getFilteredMedicineList().isEmpty());
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/commands/FindMedicineCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/FindMedicineCommandTest.java
@@ -1,0 +1,91 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.clinicio.commons.core.Messages.MESSAGE_MEDICINE_OVERVIEW;
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.testutil.TypicalPersons.PARACETAMOL;
+import static seedu.clinicio.testutil.TypicalPersons.ORACORT;
+import static seedu.clinicio.testutil.TypicalPersons.VENTOLIN;
+import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.ModelManager;
+import seedu.clinicio.model.UserPrefs;
+import seedu.clinicio.model.analytics.Analytics;
+import seedu.clinicio.model.medicine.MedicineNameContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FindMedicineCommandTest {
+
+    private Model model = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+    private Analytics analytics = new Analytics();
+
+    @Test
+    public void equals() {
+        MedicineNameContainsKeywordsPredicate firstPredicate =
+                new MedicineNameContainsKeywordsPredicate(Collections.singletonList("first"));
+        MedicineNameContainsKeywordsPredicate secondPredicate =
+                new MedicineNameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindMedicineCommand findFirstMedicineCommand = new FindMedicineCommand(firstPredicate);
+        FindMedicineCommand findSecondMedicineCommand = new FindMedicineCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstMedicineCommand.equals(findFirstMedicineCommand));
+
+        // same values -> returns true
+        FindMedicineCommand findFirstMedicineCommandCopy = new FindMedicineCommand(firstPredicate);
+        assertTrue(findFirstMedicineCommand.equals(findFirstMedicineCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstMedicineCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstMedicineCommand.equals(null));
+
+        // different medicine -> returns false
+        assertFalse(findFirstMedicineCommand.equals(findSecondMedicineCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noMedicineFound() {
+        String expectedMessage = String.format(MESSAGE_MEDICINE_OVERVIEW, 0);
+        MedicineNameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindMedicineCommand command = new FindMedicineCommand(predicate);
+        expectedModel.updateFilteredMedicineList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel, analytics);
+        assertEquals(Collections.emptyList(), model.getFilteredMedicineList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleMedicinesFound() {
+        String expectedMessage = String.format(MESSAGE_MEDICINE_OVERVIEW, 3);
+        MedicineNameContainsKeywordsPredicate predicate = preparePredicate("Paracetamol Oracort Ventolin");
+        FindMedicineCommand command = new FindMedicineCommand(predicate);
+        expectedModel.updateFilteredMedicineList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel, analytics);
+        assertEquals(Arrays.asList(PARACETAMOL, ORACORT, VENTOLIN), model.getFilteredMedicineList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code MedicineNameContainsKeywordsPredicate}.
+     */
+    private MedicineNameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new MedicineNameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/commands/ListMedicineCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/ListMedicineCommandTest.java
@@ -1,0 +1,48 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.logic.commands.CommandTestUtil.showMedicineAtIndex;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
+import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.ModelManager;
+import seedu.clinicio.model.UserPrefs;
+import seedu.clinicio.model.analytics.Analytics;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListMedicineCommand.
+ */
+public class ListMedicineCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+    private CommandHistory commandHistory = new CommandHistory();
+    private Analytics analytics = new Analytics();
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+        expectedModel = new ModelManager(model.getClinicIo(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_medicineListIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListMedicineCommand(), model, commandHistory, ListMedicineCommand.MESSAGE_SUCCESS,
+                expectedModel, analytics);
+    }
+
+    @Test
+    public void execute_medicineListIsFiltered_showsEverything() {
+        showMedicineAtIndex(model, INDEX_FIRST_MEDICINE);
+        assertCommandSuccess(new ListMedicineCommand(), model, commandHistory, ListMedicineCommand.MESSAGE_SUCCESS,
+                expectedModel, analytics);
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/RedoCommandTest.java
@@ -2,6 +2,7 @@ package seedu.clinicio.logic.commands;
 
 import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.logic.commands.CommandTestUtil.deleteFirstMedicine;
 import static seedu.clinicio.logic.commands.CommandTestUtil.deleteFirstPerson;
 import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
 
@@ -25,12 +26,12 @@ public class RedoCommandTest {
     public void setUp() {
         // set up of both models' undo/redo history
         deleteFirstPerson(model);
-        deleteFirstPerson(model);
+        deleteFirstMedicine(model);
         model.undoClinicIo();
         model.undoClinicIo();
 
         deleteFirstPerson(expectedModel);
-        deleteFirstPerson(expectedModel);
+        deleteFirstMedicine(expectedModel);
         expectedModel.undoClinicIo();
         expectedModel.undoClinicIo();
     }

--- a/src/test/java/seedu/clinicio/logic/commands/SelectMedicineCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/SelectMedicineCommandTest.java
@@ -1,0 +1,125 @@
+package seedu.clinicio.logic.commands;
+
+//@@author aaronseahyh
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.logic.commands.CommandTestUtil.showMedicineAtIndex;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_SECOND_MEDICINE;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_THIRD_MEDICINE;
+import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.clinicio.commons.core.Messages;
+import seedu.clinicio.commons.core.index.Index;
+import seedu.clinicio.commons.events.ui.JumpToListRequestEvent;
+import seedu.clinicio.logic.CommandHistory;
+import seedu.clinicio.model.Model;
+import seedu.clinicio.model.ModelManager;
+import seedu.clinicio.model.UserPrefs;
+import seedu.clinicio.model.analytics.Analytics;
+import seedu.clinicio.ui.testutil.EventsCollectorRule;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code SelectMedicineCommand}.
+ */
+public class SelectMedicineCommandTest {
+
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    private Model model = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalClinicIo(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+    private Analytics analytics = new Analytics();
+
+    @Test
+    public void execute_validIndexUnfilteredMedicineList_success() {
+        Index lastMedicineIndex = Index.fromOneBased(model.getFilteredMedicineList().size());
+
+        assertExecutionSuccess(INDEX_FIRST_MEDICINE);
+        assertExecutionSuccess(INDEX_THIRD_MEDICINE);
+        assertExecutionSuccess(lastMedicineIndex);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredMedicineList_failure() {
+        Index outOfBoundsIndex = Index.fromOneBased(model.getFilteredMedicineList().size() + 1);
+
+        assertExecutionFailure(outOfBoundsIndex, Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredMedicineList_success() {
+        showMedicineAtIndex(model, INDEX_FIRST_MEDICINE);
+        showMedicineAtIndex(expectedModel, INDEX_FIRST_MEDICINE);
+
+        assertExecutionSuccess(INDEX_FIRST_MEDICINE);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredMedicineList_failure() {
+        showMedicineAtIndex(model, INDEX_FIRST_MEDICINE);
+        showMedicineAtIndex(expectedModel, INDEX_FIRST_MEDICINE);
+
+        Index outOfBoundsIndex = INDEX_SECOND_MEDICINE;
+        // ensures that outOfBoundIndex is still in bounds of ClinicIO list
+        assertTrue(outOfBoundsIndex.getZeroBased() < model.getClinicIo().getMedicineList().size());
+
+        assertExecutionFailure(outOfBoundsIndex, Messages.MESSAGE_INVALID_MEDICINE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        SelectMedicineCommand selectFirstMedicineCommand = new SelectMedicineCommand(INDEX_FIRST_MEDICINE);
+        SelectMedicineCommand selectSecondMedicineCommand = new SelectMedicineCommand(INDEX_SECOND_MEDICINE);
+
+        // same object -> returns true
+        assertTrue(selectFirstMedicineCommand.equals(selectFirstMedicineCommand));
+
+        // same values -> returns true
+        SelectMedicineCommand selectFirstMedicineCommandCopy = new SelectMedicineCommand(INDEX_FIRST_MEDICINE);
+        assertTrue(selectFirstMedicineCommand.equals(selectFirstMedicineCommandCopy));
+
+        // different types -> returns false
+        assertFalse(selectFirstMedicineCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(selectFirstMedicineCommand.equals(null));
+
+        // different medicine -> returns false
+        assertFalse(selectFirstMedicineCommand.equals(selectSecondMedicineCommand));
+    }
+
+    /**
+     * Executes a {@code SelectMedicineCommand} with the given {@code index}, and checks that {@code JumpToListRequestEvent}
+     * is raised with the correct index.
+     */
+    private void assertExecutionSuccess(Index index) {
+        SelectMedicineCommand selectMedicineCommand = new SelectMedicineCommand(index);
+        String expectedMessage = String.format(SelectMedicineCommand.MESSAGE_SELECT_MEDICINE_SUCCESS,
+                index.getOneBased());
+
+        assertCommandSuccess(selectMedicineCommand, model, commandHistory, expectedMessage, expectedModel, analytics);
+
+        JumpToListRequestEvent lastEvent = (JumpToListRequestEvent) eventsCollectorRule.eventsCollector.getMostRecent();
+        assertEquals(index, Index.fromZeroBased(lastEvent.targetIndex));
+    }
+
+    /**
+     * Executes a {@code SelectMedicineCommand} with the given {@code index}, and checks that a {@code CommandException}
+     * is thrown with the {@code expectedMessage}.
+     */
+    private void assertExecutionFailure(Index index, String expectedMessage) {
+        SelectMedicineCommand selectMedicineCommand = new SelectMedicineCommand(index);
+        assertCommandFailure(selectMedicineCommand, model, commandHistory, analytics, expectedMessage);
+        assertTrue(eventsCollectorRule.eventsCollector.isEmpty());
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/clinicio/logic/commands/UndoCommandTest.java
@@ -2,6 +2,7 @@ package seedu.clinicio.logic.commands;
 
 import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.clinicio.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinicio.logic.commands.CommandTestUtil.deleteFirstMedicine;
 import static seedu.clinicio.logic.commands.CommandTestUtil.deleteFirstPerson;
 import static seedu.clinicio.testutil.TypicalPersons.getTypicalClinicIo;
 
@@ -25,10 +26,10 @@ public class UndoCommandTest {
     public void setUp() {
         // set up of models' undo/redo history
         deleteFirstPerson(model);
-        deleteFirstPerson(model);
+        deleteFirstMedicine(model);
 
         deleteFirstPerson(expectedModel);
-        deleteFirstPerson(expectedModel);
+        deleteFirstMedicine(expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/clinicio/logic/parser/AddMedicineCommandParserTest.java
+++ b/src/test/java/seedu/clinicio/logic/parser/AddMedicineCommandParserTest.java
@@ -1,0 +1,190 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.EFFECTIVEDOSAGE_DESC_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.EFFECTIVEDOSAGE_DESC_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.INVALID_EFFECTIVEDOSAGE_DESC;
+import static seedu.clinicio.logic.commands.CommandTestUtil.INVALID_LETHALDOSAGE_DESC;
+import static seedu.clinicio.logic.commands.CommandTestUtil.INVALID_MEDICINENAME_DESC;
+import static seedu.clinicio.logic.commands.CommandTestUtil.INVALID_MEDICINETYPE_DESC;
+import static seedu.clinicio.logic.commands.CommandTestUtil.INVALID_PRICE_DESC;
+import static seedu.clinicio.logic.commands.CommandTestUtil.INVALID_QUANTITY_DESC;
+import static seedu.clinicio.logic.commands.CommandTestUtil.LETHALDOSAGE_DESC_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.LETHALDOSAGE_DESC_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.MEDICINENAME_DESC_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.MEDICINENAME_DESC_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.MEDICINETYPE_DESC_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.MEDICINETYPE_DESC_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.clinicio.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.clinicio.logic.commands.CommandTestUtil.PRICE_DESC_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.PRICE_DESC_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.QUANTITY_DESC_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.QUANTITY_DESC_ORACORT;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_EFFECTIVEDOSAGE_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_LETHALDOSAGE_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_MEDICINENAME_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_MEDICINETYPE_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_PRICE_PARACETAMOL;
+import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_QUANTITY_PARACETAMOL;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.clinicio.testutil.TypicalPersons.PARACETAMOL;
+
+import org.junit.Test;
+
+import seedu.clinicio.logic.commands.AddMedicineCommand;
+import seedu.clinicio.model.medicine.Medicine;
+import seedu.clinicio.model.medicine.MedicineDosage;
+import seedu.clinicio.model.medicine.MedicineName;
+import seedu.clinicio.model.medicine.MedicinePrice;
+import seedu.clinicio.model.medicine.MedicineQuantity;
+import seedu.clinicio.model.medicine.MedicineType;
+import seedu.clinicio.testutil.MedicineBuilder;
+
+public class AddMedicineCommandParserTest {
+
+    private AddMedicineCommandParser parser = new AddMedicineCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Medicine expectedMedicine = new MedicineBuilder(PARACETAMOL).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + MEDICINENAME_DESC_PARACETAMOL
+                + MEDICINETYPE_DESC_PARACETAMOL + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL
+                + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+        // multiple names - last medicine name accepted
+        assertParseSuccess(parser, MEDICINENAME_DESC_ORACORT + MEDICINENAME_DESC_PARACETAMOL
+                + MEDICINETYPE_DESC_PARACETAMOL + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL
+                + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+        // multiple types - last medicine type accepted
+        assertParseSuccess(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_ORACORT
+                + MEDICINETYPE_DESC_PARACETAMOL + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL
+                + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+        // multiple effective dosages - last effective dosage accepted
+        assertParseSuccess(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                + EFFECTIVEDOSAGE_DESC_ORACORT + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL
+                + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+        // multiple lethal dosages - last lethal dosage accepted
+        assertParseSuccess(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_ORACORT + LETHALDOSAGE_DESC_PARACETAMOL
+                + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+        // multiple prices - last price accepted
+        assertParseSuccess(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_ORACORT
+                + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+        // multiple quantities - last quantity accepted
+        assertParseSuccess(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                + QUANTITY_DESC_ORACORT + QUANTITY_DESC_PARACETAMOL, new AddMedicineCommand(expectedMedicine));
+
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMedicineCommand.MESSAGE_USAGE);
+
+        // missing medicine name prefix
+        assertParseFailure(parser, VALID_MEDICINENAME_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                expectedMessage);
+
+        // missing medicine type prefix
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + VALID_MEDICINETYPE_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                expectedMessage);
+
+        // missing effective dosage prefix
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + VALID_EFFECTIVEDOSAGE_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                expectedMessage);
+
+        // missing lethal dosage prefix
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + VALID_LETHALDOSAGE_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                expectedMessage);
+
+        // missing price prefix
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + VALID_PRICE_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                expectedMessage);
+
+        // missing medicine name prefix
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + VALID_QUANTITY_PARACETAMOL,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_MEDICINENAME_PARACETAMOL + VALID_MEDICINETYPE_PARACETAMOL
+                        + VALID_EFFECTIVEDOSAGE_PARACETAMOL + VALID_LETHALDOSAGE_PARACETAMOL + VALID_PRICE_PARACETAMOL
+                        + VALID_QUANTITY_PARACETAMOL,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid medicine name
+        assertParseFailure(parser, INVALID_MEDICINENAME_DESC + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                MedicineName.MESSAGE_MEDICINE_NAME_CONSTRAINTS);
+
+        // invalid medicine type
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + INVALID_MEDICINETYPE_DESC
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                MedicineType.MESSAGE_MEDICINE_TYPE_CONSTRAINTS);
+
+        // invalid effective dosage
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + INVALID_EFFECTIVEDOSAGE_DESC + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                MedicineDosage.MESSAGE_MEDICINE_DOSAGE_CONSTRAINTS);
+
+        // invalid effective dosage
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + INVALID_LETHALDOSAGE_DESC + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                MedicineDosage.MESSAGE_MEDICINE_DOSAGE_CONSTRAINTS);
+
+        // invalid price
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + INVALID_PRICE_DESC
+                        + QUANTITY_DESC_PARACETAMOL,
+                MedicinePrice.MESSAGE_MEDICINE_PRICE_CONSTRAINTS);
+
+        // invalid quantity
+        assertParseFailure(parser, MEDICINENAME_DESC_PARACETAMOL + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL
+                        + INVALID_QUANTITY_DESC,
+                MedicineQuantity.MESSAGE_MEDICINE_QUANTITY_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_MEDICINENAME_DESC + MEDICINETYPE_DESC_PARACETAMOL
+                        + EFFECTIVEDOSAGE_DESC_PARACETAMOL + INVALID_LETHALDOSAGE_DESC + PRICE_DESC_PARACETAMOL
+                        + QUANTITY_DESC_PARACETAMOL,
+                MedicineName.MESSAGE_MEDICINE_NAME_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + MEDICINENAME_DESC_PARACETAMOL
+                        + MEDICINETYPE_DESC_PARACETAMOL + EFFECTIVEDOSAGE_DESC_PARACETAMOL
+                        + LETHALDOSAGE_DESC_PARACETAMOL + PRICE_DESC_PARACETAMOL + QUANTITY_DESC_PARACETAMOL,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMedicineCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/parser/ClinicIoParserTest.java
+++ b/src/test/java/seedu/clinicio/logic/parser/ClinicIoParserTest.java
@@ -9,6 +9,7 @@ import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_PASSWORD_ADAM;
 import static seedu.clinicio.logic.commands.CommandTestUtil.VALID_PASSWORD_ALAN;
 import static seedu.clinicio.model.staff.Role.DOCTOR;
 import static seedu.clinicio.model.staff.Role.RECEPTIONIST;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
 import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.clinicio.testutil.TypicalPersons.ADAM;
 import static seedu.clinicio.testutil.TypicalPersons.ALAN;
@@ -22,11 +23,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.clinicio.logic.commands.AddCommand;
+import seedu.clinicio.logic.commands.AddMedicineCommand;
 import seedu.clinicio.logic.commands.AddPatientCommand;
 import seedu.clinicio.logic.commands.AppointmentStatisticsCommand;
 import seedu.clinicio.logic.commands.CancelApptCommand;
 import seedu.clinicio.logic.commands.ClearCommand;
 import seedu.clinicio.logic.commands.DeleteCommand;
+import seedu.clinicio.logic.commands.DeleteMedicineCommand;
 import seedu.clinicio.logic.commands.DequeueCommand;
 import seedu.clinicio.logic.commands.DoctorStatisticsCommand;
 import seedu.clinicio.logic.commands.EditCommand;
@@ -37,25 +40,32 @@ import seedu.clinicio.logic.commands.ExportPatientsAppointmentsCommand;
 import seedu.clinicio.logic.commands.ExportPatientsCommand;
 import seedu.clinicio.logic.commands.ExportPatientsConsultationsCommand;
 import seedu.clinicio.logic.commands.FindCommand;
+import seedu.clinicio.logic.commands.FindMedicineCommand;
 import seedu.clinicio.logic.commands.HelpCommand;
 import seedu.clinicio.logic.commands.HistoryCommand;
 import seedu.clinicio.logic.commands.ListApptCommand;
 import seedu.clinicio.logic.commands.ListCommand;
+import seedu.clinicio.logic.commands.ListMedicineCommand;
 import seedu.clinicio.logic.commands.LoginCommand;
 import seedu.clinicio.logic.commands.LogoutCommand;
 import seedu.clinicio.logic.commands.PatientStatisticsCommand;
 import seedu.clinicio.logic.commands.RedoCommand;
 import seedu.clinicio.logic.commands.SelectCommand;
+import seedu.clinicio.logic.commands.SelectMedicineCommand;
 import seedu.clinicio.logic.commands.ShowPatientInQueueCommand;
 import seedu.clinicio.logic.commands.UndoCommand;
 import seedu.clinicio.logic.parser.exceptions.ParseException;
 import seedu.clinicio.model.appointment.AppointmentContainsDatePredicate;
+import seedu.clinicio.model.medicine.Medicine;
+import seedu.clinicio.model.medicine.MedicineNameContainsKeywordsPredicate;
 import seedu.clinicio.model.patient.Patient;
 import seedu.clinicio.model.person.NameContainsKeywordsPredicate;
 import seedu.clinicio.model.person.Person;
 import seedu.clinicio.model.staff.Password;
 import seedu.clinicio.model.staff.Staff;
 import seedu.clinicio.testutil.EditPersonDescriptorBuilder;
+import seedu.clinicio.testutil.MedicineBuilder;
+import seedu.clinicio.testutil.MedicineUtil;
 import seedu.clinicio.testutil.PatientBuilder;
 import seedu.clinicio.testutil.PatientUtil;
 import seedu.clinicio.testutil.PersonBuilder;
@@ -91,6 +101,14 @@ public class ClinicIoParserTest {
     }
 
     @Test
+    public void parseCommand_addMedicine() throws Exception {
+        Medicine medicine = new MedicineBuilder().build();
+        AddMedicineCommand command =
+                (AddMedicineCommand) parser.parseCommand(MedicineUtil.getAddMedicineCommand(medicine));
+        assertEquals(new AddMedicineCommand(medicine), command);
+    }
+
+    @Test
     public void parseCommand_addPatient() throws Exception {
         Patient patient = new PatientBuilder().build();
         AddPatientCommand command = (AddPatientCommand) parser
@@ -109,6 +127,13 @@ public class ClinicIoParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deleteMedicine() throws Exception {
+        DeleteMedicineCommand command = (DeleteMedicineCommand) parser.parseCommand(
+                DeleteMedicineCommand.COMMAND_WORD + " " + INDEX_FIRST_MEDICINE.getOneBased());
+        assertEquals(new DeleteMedicineCommand(INDEX_FIRST_MEDICINE), command);
     }
 
     @Test
@@ -133,6 +158,15 @@ public class ClinicIoParserTest {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_findMedicine() throws Exception {
+        List<String> keywords = Arrays.asList("paracetamol", "oracort", "ventolin");
+        FindMedicineCommand command = (FindMedicineCommand) parser.parseCommand(
+                FindMedicineCommand.COMMAND_WORD + " "
+                        + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindMedicineCommand(new MedicineNameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test
@@ -186,6 +220,13 @@ public class ClinicIoParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listMedicine() throws Exception {
+        assertTrue(parser.parseCommand(ListMedicineCommand.COMMAND_WORD) instanceof ListMedicineCommand);
+        assertTrue(parser.parseCommand(ListMedicineCommand.COMMAND_WORD + " 3")
+                instanceof ListMedicineCommand);
     }
 
     @Test
@@ -247,6 +288,13 @@ public class ClinicIoParserTest {
     }
 
     @Test
+    public void parseCommand_selectMedicine() throws Exception {
+        SelectMedicineCommand command = (SelectMedicineCommand) parser.parseCommand(
+                SelectMedicineCommand.COMMAND_WORD + " " + INDEX_FIRST_MEDICINE.getOneBased());
+        assertEquals(new SelectMedicineCommand(INDEX_FIRST_MEDICINE), command);
+    }
+
+    @Test
     public void parseCommand_redoCommandWord_returnsRedoCommand() throws Exception {
         assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
         assertTrue(parser.parseCommand("redo 1") instanceof RedoCommand);
@@ -294,4 +342,5 @@ public class ClinicIoParserTest {
         thrown.expectMessage(MESSAGE_UNKNOWN_COMMAND);
         parser.parseCommand("unknownCommand");
     }
+
 }

--- a/src/test/java/seedu/clinicio/logic/parser/DeleteMedicineCommandParserTest.java
+++ b/src/test/java/seedu/clinicio/logic/parser/DeleteMedicineCommandParserTest.java
@@ -1,0 +1,29 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
+
+import org.junit.Test;
+
+import seedu.clinicio.logic.commands.DeleteMedicineCommand;
+
+public class DeleteMedicineCommandParserTest {
+
+    private DeleteMedicineCommandParser parser = new DeleteMedicineCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteMedicineCommand() {
+        assertParseSuccess(parser, "1", new DeleteMedicineCommand(INDEX_FIRST_MEDICINE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteMedicineCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/parser/FindMedicineCommandParserTest.java
+++ b/src/test/java/seedu/clinicio/logic/parser/FindMedicineCommandParserTest.java
@@ -1,0 +1,38 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import seedu.clinicio.logic.commands.FindMedicineCommand;
+import seedu.clinicio.model.medicine.MedicineNameContainsKeywordsPredicate;
+
+public class FindMedicineCommandParserTest {
+
+    private FindMedicineCommandParser parser = new FindMedicineCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindMedicineCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindMedicineCommand() {
+        // no leading and trailing whitespaces
+        FindMedicineCommand expectedFindMedicineCommand =
+                new FindMedicineCommand(
+                        new MedicineNameContainsKeywordsPredicate(Arrays.asList("Paracetamol", "Oracort")));
+        assertParseSuccess(parser, "Paracetamol Oracort", expectedFindMedicineCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Paracetamol \n \t Oracort  \t", expectedFindMedicineCommand);
+    }
+
+}

--- a/src/test/java/seedu/clinicio/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/clinicio/logic/parser/ParserUtilTest.java
@@ -9,6 +9,7 @@ import static seedu.clinicio.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.clinicio.model.staff.Role.DOCTOR;
 import static seedu.clinicio.model.staff.Role.RECEPTIONIST;
 
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
 import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
@@ -23,6 +24,11 @@ import org.junit.rules.ExpectedException;
 import seedu.clinicio.logic.parser.exceptions.ParseException;
 import seedu.clinicio.model.appointment.Date;
 import seedu.clinicio.model.appointment.Time;
+import seedu.clinicio.model.medicine.MedicineDosage;
+import seedu.clinicio.model.medicine.MedicineName;
+import seedu.clinicio.model.medicine.MedicinePrice;
+import seedu.clinicio.model.medicine.MedicineQuantity;
+import seedu.clinicio.model.medicine.MedicineType;
 import seedu.clinicio.model.patient.Allergy;
 import seedu.clinicio.model.patient.MedicalProblem;
 import seedu.clinicio.model.patient.Medication;
@@ -62,6 +68,12 @@ public class ParserUtilTest {
     private static final String INVALID_MED = "a@bc";
     private static final String INVALID_ALLERGY = "D^st";
 
+    private static final String INVALID_MEDICINE_NAME = "Chee%e";
+    private static final String INVALID_MEDICINE_TYPE = "Cheese";
+    private static final String INVALID_DOSAGE = "12345";
+    private static final String INVALID_PRICE = "17";
+    private static final String INVALID_QUANTITY = "14A5";
+
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
@@ -85,6 +97,12 @@ public class ParserUtilTest {
     private static final String VALID_ALLERGY_1 = "Gluten Products";
     private static final String VALID_ALLERGY_2 = "Dust";
 
+    private static final String VALID_MEDICINE_NAME = "Paracetamol";
+    private static final String VALID_MEDICINE_TYPE = "Tablet";
+    private static final String VALID_DOSAGE = "717";
+    private static final String VALID_PRICE = "0.05";
+    private static final String VALID_QUANTITY = "1000";
+
     private static final String WHITESPACE = " \t\r\n";
 
     @Rule
@@ -107,9 +125,11 @@ public class ParserUtilTest {
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST_MEDICINE, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST_MEDICINE, ParserUtil.parseIndex("  1  "));
     }
 
     @Test
@@ -619,4 +639,121 @@ public class ParserUtilTest {
         Staff expectedStaff = new Staff(DOCTOR, new Name(VALID_NAME));
         assertEquals(expectedStaff, ParserUtil.parsePreferredDoctor(nameWithWhitespace));
     }
+
+    //@@author aaronseahyh
+    @Test
+    public void parseMedicineName_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseMedicineName((String) null));
+    }
+
+    @Test
+    public void parseMedicineName_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseMedicineName(INVALID_MEDICINE_NAME));
+    }
+
+    @Test
+    public void parseMedicineName_validValueWithoutWhitespace_returnsMedicineName() throws Exception {
+        MedicineName expectedMedicineName = new MedicineName(VALID_MEDICINE_NAME);
+        assertEquals(expectedMedicineName, ParserUtil.parseMedicineName(VALID_MEDICINE_NAME));
+    }
+
+    @Test
+    public void parseMedicineName_validValueWithWhitespace_returnsTrimmedMedicineName() throws Exception {
+        String medicineNameWithWhitespace = WHITESPACE + VALID_MEDICINE_NAME + WHITESPACE;
+        MedicineName expectedMedicineName = new MedicineName(VALID_MEDICINE_NAME);
+        assertEquals(expectedMedicineName, ParserUtil.parseMedicineName(medicineNameWithWhitespace));
+    }
+
+    @Test
+    public void parseMedicineType_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseMedicineType((String) null));
+    }
+
+    @Test
+    public void parseMedicineType_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseMedicineType(INVALID_MEDICINE_TYPE));
+    }
+
+    @Test
+    public void parseMedicineType_validValueWithoutWhitespace_returnsMedicineType() throws Exception {
+        MedicineType expectedMedicineType = new MedicineType(VALID_MEDICINE_TYPE);
+        assertEquals(expectedMedicineType, ParserUtil.parseMedicineType(VALID_MEDICINE_TYPE));
+    }
+
+    @Test
+    public void parseMedicineType_validValueWithWhitespace_returnsTrimmedMedicineType() throws Exception {
+        String medicineTypeWithWhitespace = WHITESPACE + VALID_MEDICINE_TYPE + WHITESPACE;
+        MedicineType expectedMedicineType = new MedicineType(VALID_MEDICINE_TYPE);
+        assertEquals(expectedMedicineType, ParserUtil.parseMedicineType(medicineTypeWithWhitespace));
+    }
+
+    @Test
+    public void parseMedicineDosage_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseDosage((String) null));
+    }
+
+    @Test
+    public void parseMedicineDosage_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseDosage(INVALID_DOSAGE));
+    }
+
+    @Test
+    public void parseMedicineDosage_validValueWithoutWhitespace_returnsMedicineDosage() throws Exception {
+        MedicineDosage expectedMedicineDosage = new MedicineDosage(VALID_DOSAGE);
+        assertEquals(expectedMedicineDosage, ParserUtil.parseDosage(VALID_DOSAGE));
+    }
+
+    @Test
+    public void parseMedicineDosage_validValueWithWhitespace_returnsTrimmedMedicineDosage() throws Exception {
+        String medicineDosageWithWhitespace = WHITESPACE + VALID_DOSAGE + WHITESPACE;
+        MedicineDosage expectedMedicineDosage = new MedicineDosage(VALID_DOSAGE);
+        assertEquals(expectedMedicineDosage, ParserUtil.parseDosage(medicineDosageWithWhitespace));
+    }
+
+    @Test
+    public void parseMedicinePrice_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parsePrice((String) null));
+    }
+
+    @Test
+    public void parseMedicinePrice_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parsePrice(INVALID_PRICE));
+    }
+
+    @Test
+    public void parseMedicinePrice_validValueWithoutWhitespace_returnsMedicinePrice() throws Exception {
+        MedicinePrice expectedMedicinePrice = new MedicinePrice(VALID_PRICE);
+        assertEquals(expectedMedicinePrice, ParserUtil.parsePrice(VALID_PRICE));
+    }
+
+    @Test
+    public void parseMedicinePrice_validValueWithWhitespace_returnsTrimmedMedicinePrice() throws Exception {
+        String medicinePriceWithWhitespace = WHITESPACE + VALID_PRICE + WHITESPACE;
+        MedicinePrice expectedMedicinePrice = new MedicinePrice(VALID_PRICE);
+        assertEquals(expectedMedicinePrice, ParserUtil.parsePrice(medicinePriceWithWhitespace));
+    }
+
+    @Test
+    public void parseMedicineQuantity_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseQuantity((String) null));
+    }
+
+    @Test
+    public void parseMedicineQuantity_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseQuantity(INVALID_QUANTITY));
+    }
+
+    @Test
+    public void parseMedicineQuantity_validValueWithoutWhitespace_returnsMedicineQuantity() throws Exception {
+        MedicineQuantity expectedMedicineQuantity = new MedicineQuantity(VALID_QUANTITY);
+        assertEquals(expectedMedicineQuantity, ParserUtil.parseQuantity(VALID_QUANTITY));
+    }
+
+    @Test
+    public void parseMedicineQuantity_validValueWithWhitespace_returnsTrimmedMedicineQuantity() throws Exception {
+        String medicineQuantityWithWhitespace = WHITESPACE + VALID_QUANTITY + WHITESPACE;
+        MedicineQuantity expectedMedicineQuantity = new MedicineQuantity(VALID_QUANTITY);
+        assertEquals(expectedMedicineQuantity, ParserUtil.parseQuantity(medicineQuantityWithWhitespace));
+    }
+
 }

--- a/src/test/java/seedu/clinicio/logic/parser/SelectMedicineCommandParserTest.java
+++ b/src/test/java/seedu/clinicio/logic/parser/SelectMedicineCommandParserTest.java
@@ -1,0 +1,29 @@
+package seedu.clinicio.logic.parser;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinicio.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.clinicio.testutil.TypicalIndexes.INDEX_FIRST_MEDICINE;
+
+import org.junit.Test;
+
+import seedu.clinicio.logic.commands.SelectMedicineCommand;
+
+public class SelectMedicineCommandParserTest {
+
+    private SelectMedicineCommandParser parser = new SelectMedicineCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSelectMedicineCommand() {
+        assertParseSuccess(parser, "1", new SelectMedicineCommand(INDEX_FIRST_MEDICINE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SelectMedicineCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/clinicio/testutil/MedicineUtil.java
+++ b/src/test/java/seedu/clinicio/testutil/MedicineUtil.java
@@ -1,0 +1,42 @@
+package seedu.clinicio.testutil;
+
+//@@author aaronseahyh
+
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_EFFECTIVE_DOSAGE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_LETHAL_DOSAGE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_NAME;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_PRICE;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_QUANTITY;
+import static seedu.clinicio.logic.parser.CliSyntax.PREFIX_MEDICINE_TYPE;
+
+import seedu.clinicio.logic.commands.AddMedicineCommand;
+
+import seedu.clinicio.model.medicine.Medicine;
+
+/**
+ * A utility class for Medicine.
+ */
+public class MedicineUtil {
+
+    /**
+     * Returns an addmed command string for adding the {@code medicine}.
+     */
+    public static String getAddMedicineCommand(Medicine medicine) {
+        return AddMedicineCommand.COMMAND_WORD + " " + getMedicineDetails(medicine);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code medicine}'s details.
+     */
+    public static String getMedicineDetails(Medicine medicine) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_MEDICINE_NAME + medicine.getMedicineName().medicineName + " ");
+        sb.append(PREFIX_MEDICINE_TYPE + medicine.getMedicineType().medicineType + " ");
+        sb.append(PREFIX_MEDICINE_EFFECTIVE_DOSAGE + medicine.getEffectiveDosage().medicineDosage + " ");
+        sb.append(PREFIX_MEDICINE_LETHAL_DOSAGE + medicine.getLethalDosage().medicineDosage + " ");
+        sb.append(PREFIX_MEDICINE_PRICE + medicine.getPrice().medicinePrice + " ");
+        sb.append(PREFIX_MEDICINE_QUANTITY + medicine.getQuantity().medicineQuantity + " ");
+        return sb.toString();
+    }
+
+}

--- a/src/test/java/seedu/clinicio/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/clinicio/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_MEDICINE = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_MEDICINE = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_MEDICINE = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/clinicio/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/clinicio/testutil/TypicalPersons.java
@@ -218,11 +218,11 @@ public class TypicalPersons {
             clinicIo.addAppointment(appointment);
         }
         */
-        /*
+
         for (Medicine medicine : getTypicalMedicines()) {
             clinicIo.addMedicine(medicine);
         }
-        */
+
         return clinicIo;
     }
 


### PR DESCRIPTION
Implemented some classes for Medicine & MedicineInventory:
1. `AddMedicineCommand`
2. `DeleteMedicineCommand`
3. `FindMedicineCommand`
4. `SelectMedicineCommand`
5. `ListMedicineCommand`
6. `AddMedicineCommandParser`
7. `DeleteMedicineCommandParser`
8. `FindMedicineCommandParser`
9. `SelectMedicineCommandParser`

Edited some classes to include MedicineInventory implementation
1. `Messages`
2. `CliSyntax`
3. `ParserUtil`
4. `ClinicIoParser`
5. `Logic`
6. `LogicManager`
7. `UndoCommand`
8. `RedoCommand`

Also, added test files for commands and command parsers, as well as updated pre-existing test files to include changes made.